### PR TITLE
Fix translation for word "by" into correct German "nach".

### DIFF
--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -200,7 +200,7 @@ msgstr "Musik Bibliothek"
 
 msgctxt "#31054"
 msgid "by"
-msgstr "bei"
+msgstr "nach"
 
 msgctxt "#31005"
 msgid "Latest"


### PR DESCRIPTION
Small correction for the german i18n file: When showing a menu like "episodes by name" the correct german translation will be "Episoden nach Name" rather than "Episoden bei Name", context matters ;)